### PR TITLE
Few improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/devanshbatham/rayder
+module github.com/RikunjSindhwad/rayder
 
 go 1.20
 


### PR DESCRIPTION
- Every module will have option to specify parallel flag
- Like projectdiscovery tools - every logs/stats are redirected to sterr apart from command output

```yml
vars:
  INPUT_DIR: "input"
  OUTPUT_DIR: "output"

modules:
  - name: mkdir
    silent: false
    parallel: false
    cmds:
      - mkdir -p {{OUTPUT_DIR}} {{INPUT_DIR}}
  - name: don't-wait-for-sleep
    silent: false
    parallel: true
    cmds:
      - echo `date` | tee {{OUTPUT_DIR}}/date
      - sleep 1
  - name: wait-for-sleep
    silent: false
    parallel: false
    cmds:
      - echo `date` | tee {{OUTPUT_DIR}}/date2
      - sleep 3
  - name: Final-sleep
    silent: false
    parallel: true
    cmds:
      - echo `date` | tee {{OUTPUT_DIR}}/date3
```

```
 ./main -w test.yaml 2> /dev/null
Thu Sep 7 12:06:18 UTC 2023
Thu Sep 7 12:06:18 UTC 2023
Thu Sep 7 12:06:21 UTC 2023

[2023-09-07 12:06:27] [INFO] Module 'mkdir' running ⚡
[2023-09-07 12:06:27] [INFO] Module 'mkdir' completed ✅
[2023-09-07 12:06:27] [INFO] Module 'wait-for-sleep' running ⚡
[2023-09-07 12:06:27] [INFO] Module 'don't-wait-for-sleep' running ⚡
Thu Sep 7 12:06:27 UTC 2023
Thu Sep 7 12:06:27 UTC 2023
[2023-09-07 12:06:28] [INFO] Module 'don't-wait-for-sleep' completed ✅
[2023-09-07 12:06:30] [INFO] Module 'wait-for-sleep' completed ✅
[2023-09-07 12:06:30] [INFO] Module 'Final-sleep' running ⚡
Thu Sep 7 12:06:30 UTC 2023
[2023-09-07 12:06:30] [INFO] Module 'Final-sleep' completed ✅
[2023-09-07 12:06:30] [INFO] All modules completed successfully ✅
```